### PR TITLE
fix: Fix build fail on mips

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cryfs (0.11.4-1deepin4) unstable; urgency=medium
+
+  * fix: Fix build fail on mips
+
+ -- wangrong <wangrong@uniontech.com>  Thu, 05 Feb 2026 17:20:51 +0800
+
 cryfs (0.11.4-1deepin3) unstable; urgency=medium
 
   * chore: improve debian build rules with architecture detection

--- a/debian/rules
+++ b/debian/rules
@@ -44,3 +44,10 @@ endif
 	# ./build/test/cryfs-cli/cryfs-cli-test
 	# Test requires root (and fuse)
 	# ./build/test/fspp/fspp-test
+
+override_dh_auto_install:
+ifeq ($(SKIP_TESTS),yes)
+	@echo "Removing test executables from debian/cryfs.install";
+	sed -i '/^build\/test\//d' debian/cryfs.install;
+endif
+	dh_install


### PR DESCRIPTION
When building on MIPS, the `debian/rules` directive prevents the test programs from being built. However, `debian/cryfs.install` consistently requests the installation of test programs, causing the packaging process to fail. Therefore. Let's not install test programs if we haven't built them yet.

Log: Fix build fail on mips